### PR TITLE
Fix 0.7 deprecation warnings

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.6
+julia 0.7
 PlotlyBase
 Reexport
 JSON

--- a/src/plotly_api.jl
+++ b/src/plotly_api.jl
@@ -10,28 +10,28 @@ end
 
 function PlotlyBase.restyle!(
         plt::WebIOPlot, ind::Union{Int,AbstractVector{Int}},
-        update::Associative=Dict();
+        update::AbstractDict=Dict();
         kwargs...)
     send_command(plt.scope, :restyle, merge(update, PlotlyBase.prep_kwargs(kwargs)), ind-1)
 end
 
-function PlotlyBase.restyle!(plt::WebIOPlot, update::Associative=Dict(); kwargs...)
+function PlotlyBase.restyle!(plt::WebIOPlot, update::AbstractDict=Dict(); kwargs...)
     restyle!(plt, 1:length(plt.p.data), update; kwargs...)
 end
 
-function PlotlyBase.relayout!(plt::WebIOPlot, update::Associative=Dict(); kwargs...)
+function PlotlyBase.relayout!(plt::WebIOPlot, update::AbstractDict=Dict(); kwargs...)
     send_command(plt.scope, :relayout, merge(update, PlotlyBase.prep_kwargs(kwargs)))
 end
 
 function PlotlyBase.update!(
         plt::WebIOPlot, ind::Union{Int,AbstractVector{Int}},
-        update::Associative=Dict();
+        update::AbstractDict=Dict();
         layout::Layout=Layout(),
         kwargs...)
 
     send_command(plt.scope, :update, merge(update, PlotlyBase.prep_kwargs(kwargs)), layout, ind-1)
 end
 
-function PlotlyBase.update!(plt::WebIOPlot, update::Associative=Dict(); kwargs...)
+function PlotlyBase.update!(plt::WebIOPlot, update::AbstractDict=Dict(); kwargs...)
     PlotlyBase.update!(plt, 1:length(plt.p.data), update; kwargs...)
 end


### PR DESCRIPTION
Looks like that's the only change necessary. The code works otherwise, at least using PlotlyBase#master. Would you prefer to use Compat?